### PR TITLE
fix: replace removed np.bool with builtin bool

### DIFF
--- a/ai-emlyon/eml/eda.py
+++ b/ai-emlyon/eml/eda.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def plot_correlations(df):
     corr_matrix = df.corr()
-    mask = np.zeros_like(corr_matrix, dtype=np.bool)
+    mask = np.zeros_like(corr_matrix, dtype=bool)
     mask[np.triu_indices_from(mask)] = True
     plt.figure(figsize=(25, 15))
     heatmap = sns.heatmap(


### PR DESCRIPTION
Fixes #385

## Problem

`np.bool` was removed from the numpy namespace in numpy 1.24.0. Accessing it raises `AttributeError: module 'numpy' has no attribute 'bool'` at runtime.

## Fix

```diff
- mask = np.zeros_like(corr_matrix, dtype=np.bool)
+ mask = np.zeros_like(corr_matrix, dtype=bool)
```

## Verification

- `bool` is the canonical replacement and numpy accepts it as a dtype with identical behavior.
- Change is a direct replacement of the removed API with its documented canonical successor — no behavioral change.